### PR TITLE
Optimize for Lambda-only invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2980,6 +2980,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "httpmock",
+ "hyper 0.14.32",
  "lambda_http",
  "lambda_runtime",
  "mockito",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.4", features = ["serde", "v4"] }
 once_cell = "1.19.0"
+hyper = { version = "0.14", features = ["server", "http1", "http2"] }
 
 [dev-dependencies]
 mockito = "1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,39 +3,26 @@ mod handlers;
 use handlers::{handle_delete, handle_get, handle_post, handle_put};
 
 pub async fn handle_request(event: Request) -> Result<Response<Body>, Error> {
-    println!("[DEBUG] Incoming request: path={}, method={}, headers={:?}", 
+    println!("[DEBUG] Lambda request: path={}, method={}, headers={:?}", 
         event.uri().path(),
         event.method(),
         event.headers());
-        
-    // Special case for Lambda test invocations
-    if event.uri().path().starts_with("/2015-03-31/functions") {
-        let method = if let Some(method_override) = event.headers().get("x-http-method-override") {
-            method_override.to_str()?
-        } else {
-            event.method().as_str()
-        };
-        
-        match method {
-            "GET" => handle_get(event).await,
-            "POST" => handle_post(event).await,
-            "PUT" => handle_put(event).await,
-            "DELETE" => handle_delete(event).await,
-            _ => Ok(Response::builder()
-                .status(405)
-                .body("Method Not Allowed".into())?),
-        }
+    
+    // Extract method from Lambda headers or fallback to request method
+    let method = if let Some(method_override) = event.headers().get("x-http-method-override") {
+        method_override.to_str()?
     } else {
-        // Normal HTTP routing
-        match event.method().as_str() {
-            "GET" => handle_get(event).await,
-            "POST" => handle_post(event).await,
-            "PUT" => handle_put(event).await,
-            "DELETE" => handle_delete(event).await,
-            _ => Ok(Response::builder()
-                .status(405)
-                .body("Method Not Allowed".into())?),
-        }
+        event.method().as_str()
+    };
+    
+    match method {
+        "GET" => handle_get(event).await,
+        "POST" => handle_post(event).await,
+        "PUT" => handle_put(event).await,
+        "DELETE" => handle_delete(event).await,
+        _ => Ok(Response::builder()
+            .status(405)
+            .body("Method Not Allowed".into())?),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,39 @@ mod handlers;
 use handlers::{handle_delete, handle_get, handle_post, handle_put};
 
 pub async fn handle_request(event: Request) -> Result<Response<Body>, Error> {
-    match event.method().as_str() {
-        "GET" => handle_get(event).await,
-        "POST" => handle_post(event).await,
-        "PUT" => handle_put(event).await,
-        "DELETE" => handle_delete(event).await,
-        _ => Ok(Response::builder()
-            .status(405)
-            .body("Method Not Allowed".into())?),
+    println!("[DEBUG] Incoming request: path={}, method={}, headers={:?}", 
+        event.uri().path(),
+        event.method(),
+        event.headers());
+        
+    // Special case for Lambda test invocations
+    if event.uri().path().starts_with("/2015-03-31/functions") {
+        let method = if let Some(method_override) = event.headers().get("x-http-method-override") {
+            method_override.to_str()?
+        } else {
+            event.method().as_str()
+        };
+        
+        match method {
+            "GET" => handle_get(event).await,
+            "POST" => handle_post(event).await,
+            "PUT" => handle_put(event).await,
+            "DELETE" => handle_delete(event).await,
+            _ => Ok(Response::builder()
+                .status(405)
+                .body("Method Not Allowed".into())?),
+        }
+    } else {
+        // Normal HTTP routing
+        match event.method().as_str() {
+            "GET" => handle_get(event).await,
+            "POST" => handle_post(event).await,
+            "PUT" => handle_put(event).await,
+            "DELETE" => handle_delete(event).await,
+            _ => Ok(Response::builder()
+                .status(405)
+                .body("Method Not Allowed".into())?),
+        }
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,84 @@
+use lambda_http::{Body, Request};
+use serde_json::json;
+use wishlist_api::handle_request;
+
+fn build_lambda_request(method: &str, path: &str, body: Option<Body>) -> Request {
+    let mut request = Request::default();
+    *request.method_mut() = method.parse().unwrap();
+    *request.uri_mut() = format!("https://example.com{}", path).parse().unwrap();
+    *request.headers_mut() = lambda_http::http::HeaderMap::new();
+    
+    if let Some(body) = body {
+        *request.body_mut() = body;
+    }
+    
+    request
+}
+
+#[tokio::test]
+async fn test_health_endpoint() {
+    let event = build_lambda_request(
+        "GET",
+        "/health",
+        Some(Body::from(
+            json!({
+                "version": "2.0",
+                "routeKey": "GET /health",
+                "rawPath": "/health",
+                "requestContext": {
+                    "http": {
+                        "method": "GET",
+                        "path": "/health"
+                    }
+                }
+            }).to_string()
+        ))
+    );
+
+    let response = handle_request(event).await.unwrap();
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.body(), &Body::from(r#"OK"#));
+}
+
+#[tokio::test] 
+async fn test_wishlists_endpoint() {
+    let event = build_lambda_request(
+        "GET",
+        "/wishlists", 
+        Some(Body::from(
+            json!({
+                "version": "2.0",
+                "routeKey": "GET /wishlists",
+                "rawPath": "/wishlists",
+                "requestContext": {
+                    "http": {
+                        "method": "GET",
+                        "path": "/wishlists"
+                    }
+                }
+            }).to_string()
+        ))
+    );
+
+    let response = handle_request(event).await.unwrap();
+    assert_eq!(response.status(), 200);
+}
+
+#[tokio::test]
+async fn test_wishlist_creation() {
+    let event = build_lambda_request(
+        "POST", 
+        "/wishlists",
+        Some(Body::from(
+            json!({
+                "id": "test1",
+                "name": "Test List",
+                "owner": "test-user",
+                "items": []
+            }).to_string()
+        ))
+    );
+
+    let response = handle_request(event).await.unwrap();
+    assert_eq!(response.status(), 201);
+}


### PR DESCRIPTION
This PR updates the request handling to:

- Remove dual-path handling (direct HTTP + Lambda)
- Focus solely on Lambda-style invocations
- Maintain debug logging for troubleshooting
- Keep method override header support